### PR TITLE
Fix duplicate generated command names

### DIFF
--- a/src/cli/model/naming.test.ts
+++ b/src/cli/model/naming.test.ts
@@ -86,6 +86,103 @@ describe("planOperation", () => {
 });
 
 describe("planOperations collision handling", () => {
+	function priorityOperation(
+		path: string,
+		operationId: string,
+	): NormalizedOperation {
+		return {
+			key: `GET ${path}`,
+			method: "GET",
+			path,
+			operationId,
+			tags: ["Issue priorities"],
+			parameters: [],
+		};
+	}
+
+	const jiraPriorities: NormalizedOperation[] = [
+		priorityOperation("/priority", "getPriorities"),
+		priorityOperation("/priority/search", "searchPriorities"),
+	];
+
+	test("uses full operation IDs when derived names still collide", () => {
+		const actions = planOperations(jiraPriorities).map((op) => op.action);
+		expect(actions).toEqual(["get-priorities", "search-priorities"]);
+	});
+
+	test("preserves an existing command while allocating derived names", () => {
+		const ops: NormalizedOperation[] = [
+			...jiraPriorities,
+			{
+				key: "POST /Priority.ListPriorities",
+				method: "POST",
+				path: "/Priority.ListPriorities",
+				operationId: "Priority.listPriorities",
+				tags: ["Issue priorities"],
+				parameters: [],
+			},
+		];
+
+		const actions = planOperations(ops).map((op) => op.action);
+		expect(actions).toEqual([
+			"get-priorities",
+			"search-priorities",
+			"list-priorities",
+		]);
+	});
+
+	test("does not allocate a command already owned by another operation", () => {
+		const ops: NormalizedOperation[] = [
+			{
+				key: "GET /deployments/{id}",
+				method: "GET",
+				path: "/deployments/{id}",
+				operationId: "getDeployment",
+				tags: ["deployments"],
+				parameters: [],
+			},
+			{
+				key: "GET /deployments/{id}/events",
+				method: "GET",
+				path: "/deployments/{id}/events",
+				operationId: "getDeploymentEvents",
+				tags: ["deployments"],
+				parameters: [],
+			},
+			{
+				key: "POST /Deployments.GetEvents",
+				method: "POST",
+				path: "/Deployments.GetEvents",
+				operationId: "Deployments.getEvents",
+				tags: ["deployments"],
+				parameters: [],
+			},
+		];
+
+		const actions = planOperations(ops).map((op) => op.action);
+		expect(actions).toEqual(["get-1", "get-deployment-events", "get-events"]);
+	});
+
+	test("uses paths when operation IDs cannot distinguish a collision", () => {
+		const ops: NormalizedOperation[] = [
+			priorityOperation("/priority/active", "getPriorities"),
+			priorityOperation("/priority/archived", "getPriorities"),
+		];
+
+		const actions = planOperations(ops).map((op) => op.action);
+		expect(actions).toEqual(["list-priority-active", "list-priority-archived"]);
+	});
+
+	test("uses a numeric suffix only without semantic distinction", () => {
+		const ops: NormalizedOperation[] = [
+			priorityOperation("/priority/{id}", "getPriorities"),
+			priorityOperation("/priority/{key}", "getPriorities"),
+		];
+
+		const actions = planOperations(ops).map((op) => op.action);
+		expect(actions).toEqual(["get-priorities", "get-priorities-2"]);
+	});
+
 	test("disambiguates colliding creates with meaningful names", () => {
 		const ops: NormalizedOperation[] = [
 			{

--- a/src/cli/model/naming.test.ts
+++ b/src/cli/model/naming.test.ts
@@ -160,7 +160,11 @@ describe("planOperations collision handling", () => {
 		];
 
 		const actions = planOperations(ops).map((op) => op.action);
-		expect(actions).toEqual(["get-1", "get-deployment-events", "get-events"]);
+		expect(actions).toEqual([
+			"get-deployment",
+			"get-deployment-events",
+			"get-events",
+		]);
 	});
 
 	test("uses paths when operation IDs cannot distinguish a collision", () => {
@@ -210,7 +214,7 @@ describe("planOperations collision handling", () => {
 		expect(planned[1]?.action).toBe("create-upload-files");
 	});
 
-	test("disambiguates colliding gets with meaningful names from operationId", () => {
+	test("uses meaningful operation IDs before numeric suffixes", () => {
 		const ops: NormalizedOperation[] = [
 			{
 				key: "GET /deployments/{idOrUrl}",
@@ -239,9 +243,8 @@ describe("planOperations collision handling", () => {
 		];
 
 		const planned = planOperations(ops);
-		// Should extract meaningful disambiguators from operationId and path
-		// First one has no extra info, falls back to numeric suffix
-		expect(planned[0]?.action).toBe("get-1");
+		// The full operation ID is preferable when no shorter name can be derived.
+		expect(planned[0]?.action).toBe("get-deployment");
 		// Second extracts "events" from operationId
 		expect(planned[1]?.action).toBe("get-events");
 		// Third extracts "files" from operationId (list -> get canonicalization doesn't affect disambiguator)
@@ -273,7 +276,7 @@ describe("planOperations collision handling", () => {
 		expect(planned[1]?.action).toBe("create");
 	});
 
-	test("falls back to path segment when operationId has no extra info", () => {
+	test("uses operation IDs and paths before numeric suffixes", () => {
 		const ops: NormalizedOperation[] = [
 			{
 				key: "GET /users/{id}",
@@ -294,7 +297,7 @@ describe("planOperations collision handling", () => {
 		];
 
 		const planned = planOperations(ops);
-		expect(planned[0]?.action).toBe("get-1");
+		expect(planned[0]?.action).toBe("get-user");
 		expect(planned[1]?.action).toBe("get-profile");
 	});
 });

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -210,6 +210,50 @@ function deriveDisambiguatedAction(op: PlannedOperation, idx: number): string {
 	return `${op.action}-${idx}`;
 }
 
+function derivePathIdentityAction(op: PlannedOperation): string {
+	const path = kebabCase(op.path.replace(/\{[^}]+\}/g, ""));
+	return path ? `${op.action}-${path}` : "";
+}
+
+type CollisionCandidate = {
+	operation: PlannedOperation;
+	candidates: {
+		preferred: string;
+		operationId: string;
+		path: string;
+	};
+	action: string;
+};
+
+function claimUniqueActions(
+	candidates: CollisionCandidate[],
+	source: keyof CollisionCandidate["candidates"],
+	allocatedCommands: Set<string>,
+): void {
+	const counts = new Map<string, number>();
+	for (const candidate of candidates) {
+		if (candidate.action) continue;
+		const action = candidate.candidates[source];
+		if (!action) continue;
+		const command = `${candidate.operation.resource}:${action}`;
+		counts.set(command, (counts.get(command) ?? 0) + 1);
+	}
+
+	for (const candidate of candidates) {
+		if (candidate.action) continue;
+		const action = candidate.candidates[source];
+		const command = `${candidate.operation.resource}:${action}`;
+		if (
+			action &&
+			counts.get(command) === 1 &&
+			!allocatedCommands.has(command)
+		) {
+			candidate.action = action;
+			allocatedCommands.add(command);
+		}
+	}
+}
+
 function canonicalizeAction(action: string): string {
 	const a = kebabCase(action);
 
@@ -295,28 +339,65 @@ export function planOperation(op: NormalizedOperation): PlannedOperation {
 export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 	const planned = ops.map(planOperation);
 
-	// Stable collision handling: if resource+action repeats, add a suffix.
 	const counts = new Map<string, number>();
 	for (const op of planned) {
 		const key = `${op.resource}:${op.action}`;
 		counts.set(key, (counts.get(key) ?? 0) + 1);
 	}
+	const allocatedCommands = new Set(
+		[...counts].filter(([, count]) => count === 1).map(([command]) => command),
+	);
 
 	const seen = new Map<string, number>();
-	return planned.map((op) => {
+	const candidates: CollisionCandidate[] = [];
+	for (const op of planned) {
 		const key = `${op.resource}:${op.action}`;
 		const total = counts.get(key) ?? 0;
-		if (total <= 1) return op;
+		if (total <= 1) continue;
 
 		const idx = (seen.get(key) ?? 0) + 1;
 		seen.set(key, idx);
+		candidates.push({
+			operation: op,
+			candidates: {
+				preferred: deriveDisambiguatedAction(op, idx),
+				operationId: kebabCase(op.operationId ?? ""),
+				path: derivePathIdentityAction(op),
+			},
+			action: "",
+		});
+	}
 
-		const disambiguatedAction = deriveDisambiguatedAction(op, idx);
+	// Preserve existing names before falling back to authored and route identity.
+	for (const source of ["preferred", "operationId", "path"] as const) {
+		claimUniqueActions(candidates, source, allocatedCommands);
+	}
 
-		return {
-			...op,
-			action: disambiguatedAction,
-			aliasOf: `${op.resource} ${op.canonicalAction}`,
-		};
+	for (const candidate of candidates) {
+		if (candidate.action) continue;
+		const { operation } = candidate;
+		const preferred = candidate.candidates.preferred;
+		let action = preferred;
+		let suffix = 2;
+		while (allocatedCommands.has(`${operation.resource}:${action}`)) {
+			action = `${preferred}-${suffix}`;
+			suffix++;
+		}
+		candidate.action = action;
+		allocatedCommands.add(`${operation.resource}:${action}`);
+	}
+
+	const actions = new Map(
+		candidates.map(({ operation, action }) => [operation, action]),
+	);
+	return planned.map((op) => {
+		const action = actions.get(op);
+		return action
+			? {
+					...op,
+					action,
+					aliasOf: `${op.resource} ${op.canonicalAction}`,
+				}
+			: op;
 	});
 }

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -211,7 +211,8 @@ function deriveDisambiguatedAction(op: PlannedOperation, idx: number): string {
 }
 
 function derivePathIdentityAction(op: PlannedOperation): string {
-	const path = kebabCase(op.path.replace(/\{[^}]+\}/g, ""));
+	const re = /\{[^}]+\}/g;
+	const path = kebabCase(op.path.replace(re, ""));
 	return path ? `${op.action}-${path}` : "";
 }
 
@@ -222,17 +223,17 @@ type CollisionCandidate = {
 		operationId: string;
 		path: string;
 	};
-	action: string;
+	assignedAction?: string;
 };
 
-function claimUniqueActions(
+function assignUniqueActions(
 	candidates: CollisionCandidate[],
 	source: keyof CollisionCandidate["candidates"],
 	allocatedCommands: Set<string>,
 ): void {
 	const counts = new Map<string, number>();
 	for (const candidate of candidates) {
-		if (candidate.action) continue;
+		if (candidate.assignedAction !== undefined) continue;
 		const action = candidate.candidates[source];
 		if (!action) continue;
 		const command = `${candidate.operation.resource}:${action}`;
@@ -240,7 +241,7 @@ function claimUniqueActions(
 	}
 
 	for (const candidate of candidates) {
-		if (candidate.action) continue;
+		if (candidate.assignedAction !== undefined) continue;
 		const action = candidate.candidates[source];
 		const command = `${candidate.operation.resource}:${action}`;
 		if (
@@ -248,7 +249,7 @@ function claimUniqueActions(
 			counts.get(command) === 1 &&
 			!allocatedCommands.has(command)
 		) {
-			candidate.action = action;
+			candidate.assignedAction = action;
 			allocatedCommands.add(command);
 		}
 	}
@@ -339,14 +340,18 @@ export function planOperation(op: NormalizedOperation): PlannedOperation {
 export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 	const planned = ops.map(planOperation);
 
+	// Count initial commands so only colliding operations are reallocated.
 	const counts = new Map<string, number>();
 	for (const op of planned) {
 		const key = `${op.resource}:${op.action}`;
 		counts.set(key, (counts.get(key) ?? 0) + 1);
 	}
-	const allocatedCommands = new Set(
-		[...counts].filter(([, count]) => count === 1).map(([command]) => command),
-	);
+
+	// Reserve non-colliding commands so fallback names cannot replace them.
+	const allocatedCommands = new Set<string>();
+	for (const [command, count] of counts) {
+		if (count === 1) allocatedCommands.add(command);
+	}
 
 	const seen = new Map<string, number>();
 	const candidates: CollisionCandidate[] = [];
@@ -364,17 +369,16 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 				operationId: kebabCase(op.operationId ?? ""),
 				path: derivePathIdentityAction(op),
 			},
-			action: "",
 		});
 	}
 
-	// Preserve existing names before falling back to authored and route identity.
+	// Assign each operation at the first tier where its name is unique and free.
 	for (const source of ["preferred", "operationId", "path"] as const) {
-		claimUniqueActions(candidates, source, allocatedCommands);
+		assignUniqueActions(candidates, source, allocatedCommands);
 	}
 
 	for (const candidate of candidates) {
-		if (candidate.action) continue;
+		if (candidate.assignedAction !== undefined) continue;
 		const { operation } = candidate;
 		const preferred = candidate.candidates.preferred;
 		let action = preferred;
@@ -383,16 +387,19 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 			action = `${preferred}-${suffix}`;
 			suffix++;
 		}
-		candidate.action = action;
+		candidate.assignedAction = action;
 		allocatedCommands.add(`${operation.resource}:${action}`);
 	}
 
 	const actions = new Map(
-		candidates.map(({ operation, action }) => [operation, action]),
+		candidates.map(({ operation, assignedAction }) => [
+			operation,
+			assignedAction,
+		]),
 	);
 	return planned.map((op) => {
 		const action = actions.get(op);
-		return action
+		return action !== undefined
 			? {
 					...op,
 					action,

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -180,7 +180,10 @@ function extractDisambiguator(
  * Derives a disambiguated action name for colliding operations.
  * Tries to create meaningful names like "get-events" instead of "get-get-deployment-events-1".
  */
-function deriveDisambiguatedAction(op: PlannedOperation, idx: number): string {
+function deriveDisambiguatedAction(
+	op: PlannedOperation,
+	numericSuffix: number,
+): string {
 	if (op.operationId) {
 		const disambiguator = extractDisambiguator(
 			op.operationId,
@@ -207,7 +210,7 @@ function deriveDisambiguatedAction(op: PlannedOperation, idx: number): string {
 	}
 
 	// Last resort: append numeric suffix
-	return `${op.action}-${idx}`;
+	return `${op.action}-${numericSuffix}`;
 }
 
 function derivePathIdentityAction(op: PlannedOperation): string {
@@ -217,9 +220,9 @@ function derivePathIdentityAction(op: PlannedOperation): string {
 }
 
 type ActionCandidates = {
-	preferred: string;
+	derived: string;
 	operationId: string;
-	path: string;
+	pathIdentity: string;
 };
 
 type CollisionCandidate = {
@@ -228,38 +231,57 @@ type CollisionCandidate = {
 	assignedAction?: string;
 };
 
+type ActionProposal = {
+	candidate: CollisionCandidate;
+	action: string;
+	commandKey: string;
+};
+
+const ACTION_CANDIDATE_ORDER = [
+	"derived",
+	"operationId",
+	"pathIdentity",
+] as const;
+
+function buildCommandKey(resource: string, action: string): string {
+	return `${resource}:${action}`;
+}
+
 /**
- * Assign one fallback tier to unresolved collisions.
+ * Assign the best available action to every colliding operation.
  *
- * Count every proposal before assigning any of them, so a name is used only
- * when it is unique within this tier and has not already been allocated.
+ * Try the existing derived action first, then the authored operation ID, then
+ * the request path. For each option, collect every unresolved proposal before
+ * assigning any. A proposal is accepted only when no other unresolved operation
+ * proposes the same command and the global allocation does not already contain it.
  */
 function assignUniqueActions(
 	candidates: CollisionCandidate[],
-	source: keyof ActionCandidates,
 	allocatedCommands: Set<string>,
 ): void {
-	const unassignedCandidates = candidates.filter(
-		(candidate) => !candidate.assignedAction,
-	);
-	const proposalCounts = new Map<string, number>();
-	for (const candidate of unassignedCandidates) {
-		const action = candidate.actionCandidates[source];
-		if (!action) continue;
-		const command = `${candidate.operation.resource}:${action}`;
-		proposalCounts.set(command, (proposalCounts.get(command) ?? 0) + 1);
-	}
+	for (const source of ACTION_CANDIDATE_ORDER) {
+		const unassignedCandidates = candidates.filter(
+			(candidate) => !candidate.assignedAction,
+		);
+		const proposals: ActionProposal[] = [];
+		const proposalCounts = new Map<string, number>();
 
-	for (const candidate of unassignedCandidates) {
-		const action = candidate.actionCandidates[source];
-		const command = `${candidate.operation.resource}:${action}`;
-		if (
-			action &&
-			proposalCounts.get(command) === 1 &&
-			!allocatedCommands.has(command)
-		) {
-			candidate.assignedAction = action;
-			allocatedCommands.add(command);
+		for (const candidate of unassignedCandidates) {
+			const action = candidate.actionCandidates[source];
+			if (!action) continue;
+			const commandKey = buildCommandKey(candidate.operation.resource, action);
+			proposals.push({ candidate, action, commandKey });
+			proposalCounts.set(commandKey, (proposalCounts.get(commandKey) ?? 0) + 1);
+		}
+
+		for (const proposal of proposals) {
+			const isUniqueAndAvailable =
+				proposalCounts.get(proposal.commandKey) === 1 &&
+				!allocatedCommands.has(proposal.commandKey);
+			if (!isUniqueAndAvailable) continue;
+
+			proposal.candidate.assignedAction = proposal.action;
+			allocatedCommands.add(proposal.commandKey);
 		}
 	}
 }
@@ -352,54 +374,54 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 	// Count initial commands so only colliding operations are reallocated.
 	const commandCounts = new Map<string, number>();
 	for (const op of planned) {
-		const command = `${op.resource}:${op.action}`;
-		commandCounts.set(command, (commandCounts.get(command) ?? 0) + 1);
+		const commandKey = buildCommandKey(op.resource, op.action);
+		commandCounts.set(commandKey, (commandCounts.get(commandKey) ?? 0) + 1);
 	}
 
 	// Reserve non-colliding commands so fallback names cannot replace them.
 	const allocatedCommands = new Set<string>();
-	for (const [command, count] of commandCounts) {
-		if (count === 1) allocatedCommands.add(command);
+	for (const [commandKey, count] of commandCounts) {
+		if (count === 1) allocatedCommands.add(commandKey);
 	}
 
-	const collisionIndexes = new Map<string, number>();
+	// Number operations within each collision group for numeric fallbacks.
+	const numericSuffixCounts = new Map<string, number>();
 	const collisionCandidates: CollisionCandidate[] = [];
 	for (const op of planned) {
-		const command = `${op.resource}:${op.action}`;
-		const collisionCount = commandCounts.get(command) ?? 0;
+		const commandKey = buildCommandKey(op.resource, op.action);
+		const collisionCount = commandCounts.get(commandKey) ?? 0;
 		if (collisionCount <= 1) continue;
 
-		const index = (collisionIndexes.get(command) ?? 0) + 1;
-		collisionIndexes.set(command, index);
+		const numericSuffix = (numericSuffixCounts.get(commandKey) ?? 0) + 1;
+		numericSuffixCounts.set(commandKey, numericSuffix);
 		collisionCandidates.push({
 			operation: op,
 			actionCandidates: {
-				preferred: deriveDisambiguatedAction(op, index),
+				derived: deriveDisambiguatedAction(op, numericSuffix),
 				operationId: kebabCase(op.operationId ?? ""),
-				path: derivePathIdentityAction(op),
+				pathIdentity: derivePathIdentityAction(op),
 			},
 		});
 	}
 
-	// Assign each operation at the first tier where its name is unique and free.
-	for (const source of ["preferred", "operationId", "path"] as const) {
-		assignUniqueActions(collisionCandidates, source, allocatedCommands);
-	}
+	assignUniqueActions(collisionCandidates, allocatedCommands);
 
 	for (const candidate of collisionCandidates) {
 		if (candidate.assignedAction) continue;
 
 		// None of the meaningful candidates was both unique and available.
 		const { operation } = candidate;
-		const preferred = candidate.actionCandidates.preferred;
-		let action = preferred;
+		const derivedAction = candidate.actionCandidates.derived;
+		let action = derivedAction;
 		let suffix = 2;
-		while (allocatedCommands.has(`${operation.resource}:${action}`)) {
-			action = `${preferred}-${suffix}`;
+		let commandKey = buildCommandKey(operation.resource, action);
+		while (allocatedCommands.has(commandKey)) {
+			action = `${derivedAction}-${suffix}`;
+			commandKey = buildCommandKey(operation.resource, action);
 			suffix++;
 		}
 		candidate.assignedAction = action;
-		allocatedCommands.add(`${operation.resource}:${action}`);
+		allocatedCommands.add(commandKey);
 	}
 
 	const assignedActions = new Map(

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -176,14 +176,8 @@ function extractDisambiguator(
 	return name;
 }
 
-/**
- * Derives a disambiguated action name for colliding operations.
- * Tries to create meaningful names like "get-events" instead of "get-get-deployment-events-1".
- */
-function deriveDisambiguatedAction(
-	op: PlannedOperation,
-	numericSuffix: number,
-): string {
+/** Derive a meaningful action name without adding a numeric suffix. */
+function deriveSemanticAction(op: PlannedOperation): string | undefined {
 	if (op.operationId) {
 		const disambiguator = extractDisambiguator(
 			op.operationId,
@@ -209,79 +203,82 @@ function deriveDisambiguatedAction(
 		}
 	}
 
-	// Last resort: append numeric suffix
-	return `${op.action}-${numericSuffix}`;
+	return undefined;
 }
 
-function derivePathIdentityAction(op: PlannedOperation): string {
+function deriveOperationIdAction(op: PlannedOperation): string | undefined {
+	return op.operationId ? kebabCase(op.operationId) : undefined;
+}
+
+function derivePathIdentityAction(op: PlannedOperation): string | undefined {
 	const re = /\{[^}]+\}/g;
 	const path = kebabCase(op.path.replace(re, ""));
-	return path ? `${op.action}-${path}` : "";
+	return path ? `${op.action}-${path}` : undefined;
 }
-
-type ActionCandidates = {
-	derived: string;
-	operationId: string;
-	pathIdentity: string;
-};
 
 type CollisionCandidate = {
 	operation: PlannedOperation;
-	actionCandidates: ActionCandidates;
+	semanticAction: string | undefined;
+	fallbackBaseAction: string;
 	assignedAction?: string;
 };
 
-type ActionProposal = {
+type CandidateCommand = {
 	candidate: CollisionCandidate;
 	action: string;
 	commandKey: string;
 };
 
-const ACTION_CANDIDATE_ORDER = [
-	"derived",
-	"operationId",
-	"pathIdentity",
-] as const;
+type ActionOption = (candidate: CollisionCandidate) => string | undefined;
+
+const MEANINGFUL_ACTION_OPTIONS: ActionOption[] = [
+	(candidate) => candidate.semanticAction,
+	(candidate) => deriveOperationIdAction(candidate.operation),
+	(candidate) => derivePathIdentityAction(candidate.operation),
+];
 
 function buildCommandKey(resource: string, action: string): string {
 	return `${resource}:${action}`;
 }
 
 /**
- * Assign the best available action to every colliding operation.
+ * Assign the best available meaningful action to every colliding operation.
  *
- * Try the existing derived action first, then the authored operation ID, then
- * the request path. For each option, collect every unresolved proposal before
- * assigning any. A proposal is accepted only when no other unresolved operation
- * proposes the same command and the global allocation does not already contain it.
+ * Try a short action derived from the operation ID or path first, then the full
+ * operation ID, then the full request path. For each option, calculate every
+ * unassigned operation's command before assigning any. Use a command only when
+ * exactly one operation would receive it and it is not already in use.
  */
-function assignUniqueActions(
+function assignMeaningfulActions(
 	candidates: CollisionCandidate[],
 	allocatedCommands: Set<string>,
 ): void {
-	for (const source of ACTION_CANDIDATE_ORDER) {
+	for (const getAction of MEANINGFUL_ACTION_OPTIONS) {
 		const unassignedCandidates = candidates.filter(
 			(candidate) => !candidate.assignedAction,
 		);
-		const proposals: ActionProposal[] = [];
-		const proposalCounts = new Map<string, number>();
+		const candidateCommands: CandidateCommand[] = [];
+		const candidateCommandCounts = new Map<string, number>();
 
 		for (const candidate of unassignedCandidates) {
-			const action = candidate.actionCandidates[source];
+			const action = getAction(candidate);
 			if (!action) continue;
 			const commandKey = buildCommandKey(candidate.operation.resource, action);
-			proposals.push({ candidate, action, commandKey });
-			proposalCounts.set(commandKey, (proposalCounts.get(commandKey) ?? 0) + 1);
+			candidateCommands.push({ candidate, action, commandKey });
+			candidateCommandCounts.set(
+				commandKey,
+				(candidateCommandCounts.get(commandKey) ?? 0) + 1,
+			);
 		}
 
-		for (const proposal of proposals) {
+		for (const candidateCommand of candidateCommands) {
 			const isUniqueAndAvailable =
-				proposalCounts.get(proposal.commandKey) === 1 &&
-				!allocatedCommands.has(proposal.commandKey);
+				candidateCommandCounts.get(candidateCommand.commandKey) === 1 &&
+				!allocatedCommands.has(candidateCommand.commandKey);
 			if (!isUniqueAndAvailable) continue;
 
-			proposal.candidate.assignedAction = proposal.action;
-			allocatedCommands.add(proposal.commandKey);
+			candidateCommand.candidate.assignedAction = candidateCommand.action;
+			allocatedCommands.add(candidateCommand.commandKey);
 		}
 	}
 }
@@ -394,29 +391,27 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 
 		const numericSuffix = (numericSuffixCounts.get(commandKey) ?? 0) + 1;
 		numericSuffixCounts.set(commandKey, numericSuffix);
+		const semanticAction = deriveSemanticAction(op);
 		collisionCandidates.push({
 			operation: op,
-			actionCandidates: {
-				derived: deriveDisambiguatedAction(op, numericSuffix),
-				operationId: kebabCase(op.operationId ?? ""),
-				pathIdentity: derivePathIdentityAction(op),
-			},
+			semanticAction,
+			fallbackBaseAction: semanticAction ?? `${op.action}-${numericSuffix}`,
 		});
 	}
 
-	assignUniqueActions(collisionCandidates, allocatedCommands);
+	assignMeaningfulActions(collisionCandidates, allocatedCommands);
 
 	for (const candidate of collisionCandidates) {
 		if (candidate.assignedAction) continue;
 
-		// None of the meaningful candidates was both unique and available.
+		// Numeric suffixes are the last resort after every meaningful option fails.
 		const { operation } = candidate;
-		const derivedAction = candidate.actionCandidates.derived;
-		let action = derivedAction;
+		const { fallbackBaseAction } = candidate;
+		let action = fallbackBaseAction;
 		let suffix = 2;
 		let commandKey = buildCommandKey(operation.resource, action);
 		while (allocatedCommands.has(commandKey)) {
-			action = `${derivedAction}-${suffix}`;
+			action = `${fallbackBaseAction}-${suffix}`;
 			commandKey = buildCommandKey(operation.resource, action);
 			suffix++;
 		}

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -216,37 +216,46 @@ function derivePathIdentityAction(op: PlannedOperation): string {
 	return path ? `${op.action}-${path}` : "";
 }
 
+type ActionCandidates = {
+	preferred: string;
+	operationId: string;
+	path: string;
+};
+
 type CollisionCandidate = {
 	operation: PlannedOperation;
-	candidates: {
-		preferred: string;
-		operationId: string;
-		path: string;
-	};
+	actionCandidates: ActionCandidates;
 	assignedAction?: string;
 };
 
+/**
+ * Assign one fallback tier to unresolved collisions.
+ *
+ * Count every proposal before assigning any of them, so a name is used only
+ * when it is unique within this tier and has not already been allocated.
+ */
 function assignUniqueActions(
 	candidates: CollisionCandidate[],
-	source: keyof CollisionCandidate["candidates"],
+	source: keyof ActionCandidates,
 	allocatedCommands: Set<string>,
 ): void {
-	const counts = new Map<string, number>();
-	for (const candidate of candidates) {
-		if (candidate.assignedAction !== undefined) continue;
-		const action = candidate.candidates[source];
+	const unassignedCandidates = candidates.filter(
+		(candidate) => !candidate.assignedAction,
+	);
+	const proposalCounts = new Map<string, number>();
+	for (const candidate of unassignedCandidates) {
+		const action = candidate.actionCandidates[source];
 		if (!action) continue;
 		const command = `${candidate.operation.resource}:${action}`;
-		counts.set(command, (counts.get(command) ?? 0) + 1);
+		proposalCounts.set(command, (proposalCounts.get(command) ?? 0) + 1);
 	}
 
-	for (const candidate of candidates) {
-		if (candidate.assignedAction !== undefined) continue;
-		const action = candidate.candidates[source];
+	for (const candidate of unassignedCandidates) {
+		const action = candidate.actionCandidates[source];
 		const command = `${candidate.operation.resource}:${action}`;
 		if (
 			action &&
-			counts.get(command) === 1 &&
+			proposalCounts.get(command) === 1 &&
 			!allocatedCommands.has(command)
 		) {
 			candidate.assignedAction = action;
@@ -341,31 +350,31 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 	const planned = ops.map(planOperation);
 
 	// Count initial commands so only colliding operations are reallocated.
-	const counts = new Map<string, number>();
+	const commandCounts = new Map<string, number>();
 	for (const op of planned) {
-		const key = `${op.resource}:${op.action}`;
-		counts.set(key, (counts.get(key) ?? 0) + 1);
+		const command = `${op.resource}:${op.action}`;
+		commandCounts.set(command, (commandCounts.get(command) ?? 0) + 1);
 	}
 
 	// Reserve non-colliding commands so fallback names cannot replace them.
 	const allocatedCommands = new Set<string>();
-	for (const [command, count] of counts) {
+	for (const [command, count] of commandCounts) {
 		if (count === 1) allocatedCommands.add(command);
 	}
 
-	const seen = new Map<string, number>();
-	const candidates: CollisionCandidate[] = [];
+	const collisionIndexes = new Map<string, number>();
+	const collisionCandidates: CollisionCandidate[] = [];
 	for (const op of planned) {
-		const key = `${op.resource}:${op.action}`;
-		const total = counts.get(key) ?? 0;
-		if (total <= 1) continue;
+		const command = `${op.resource}:${op.action}`;
+		const collisionCount = commandCounts.get(command) ?? 0;
+		if (collisionCount <= 1) continue;
 
-		const idx = (seen.get(key) ?? 0) + 1;
-		seen.set(key, idx);
-		candidates.push({
+		const index = (collisionIndexes.get(command) ?? 0) + 1;
+		collisionIndexes.set(command, index);
+		collisionCandidates.push({
 			operation: op,
-			candidates: {
-				preferred: deriveDisambiguatedAction(op, idx),
+			actionCandidates: {
+				preferred: deriveDisambiguatedAction(op, index),
 				operationId: kebabCase(op.operationId ?? ""),
 				path: derivePathIdentityAction(op),
 			},
@@ -374,13 +383,15 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 
 	// Assign each operation at the first tier where its name is unique and free.
 	for (const source of ["preferred", "operationId", "path"] as const) {
-		assignUniqueActions(candidates, source, allocatedCommands);
+		assignUniqueActions(collisionCandidates, source, allocatedCommands);
 	}
 
-	for (const candidate of candidates) {
-		if (candidate.assignedAction !== undefined) continue;
+	for (const candidate of collisionCandidates) {
+		if (candidate.assignedAction) continue;
+
+		// None of the meaningful candidates was both unique and available.
 		const { operation } = candidate;
-		const preferred = candidate.candidates.preferred;
+		const preferred = candidate.actionCandidates.preferred;
 		let action = preferred;
 		let suffix = 2;
 		while (allocatedCommands.has(`${operation.resource}:${action}`)) {
@@ -391,15 +402,15 @@ export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 		allocatedCommands.add(`${operation.resource}:${action}`);
 	}
 
-	const actions = new Map(
-		candidates.map(({ operation, assignedAction }) => [
+	const assignedActions = new Map(
+		collisionCandidates.map(({ operation, assignedAction }) => [
 			operation,
 			assignedAction,
 		]),
 	);
 	return planned.map((op) => {
-		const action = actions.get(op);
-		return action !== undefined
+		const action = assignedActions.get(op);
+		return action
 			? {
 					...op,
 					action,


### PR DESCRIPTION
## Summary

- allocate names across the full operation set so collision fallbacks cannot create second-order collisions
- preserve existing command names, then try the existing semantic derivation, authored operation IDs, path identity, and numeric suffixes only as a last resort
- cover the Jira priority routes from issue #7, duplicate operation IDs, semantically indistinguishable paths, and names already owned by another operation

## Verification

- `bun test src` — 138 tests passed
- `./node_modules/.bin/biome ci src`
- `bun run build`

Fixes #7
