### PR TITLE
fix(naming): guarantee unique command names for colliding operations- #5

### DIFF
--- a/src/cli/model/naming.test.ts
+++ b/src/cli/model/naming.test.ts
@@ -153,7 +153,7 @@ describe("planOperations collision handling", () => {
 
 	test("disambiguated names never collide with each other", () => {
 		// Both operationIds reduce to the same disambiguator ("priorities"),
-		// which used to produce two `list-priorities` commands.
+		// so the second operation must take a different name.
 		const ops: NormalizedOperation[] = [
 			{
 				key: "GET /priority",
@@ -241,8 +241,7 @@ describe("planOperations collision handling", () => {
 
 	test("numbers colliding operations consecutively", () => {
 		// Only operations that actually fall back to a number consume one, so
-		// the sequence has no gaps. The previous counter incremented once per
-		// group member regardless, which named the third operation "get-3".
+		// the sequence has no gaps.
 		const ops: NormalizedOperation[] = [
 			{
 				key: "GET /users/{id}",

--- a/src/cli/model/naming.test.ts
+++ b/src/cli/model/naming.test.ts
@@ -239,6 +239,43 @@ describe("planOperations collision handling", () => {
 		expect(planned[1]?.action).toBe("create");
 	});
 
+	test("numbers colliding operations consecutively", () => {
+		// Only operations that actually fall back to a number consume one, so
+		// the sequence has no gaps. The previous counter incremented once per
+		// group member regardless, which named the third operation "get-3".
+		const ops: NormalizedOperation[] = [
+			{
+				key: "GET /users/{id}",
+				method: "GET",
+				path: "/users/{id}",
+				operationId: "getUser",
+				tags: ["users"],
+				parameters: [],
+			},
+			{
+				key: "GET /users/{id}/profile",
+				method: "GET",
+				path: "/users/{id}/profile",
+				operationId: "getUser",
+				tags: ["users"],
+				parameters: [],
+			},
+			{
+				key: "GET /users/{id}/user",
+				method: "GET",
+				path: "/users/{id}/user",
+				operationId: "getUser",
+				tags: ["users"],
+				parameters: [],
+			},
+		];
+
+		const planned = planOperations(ops);
+		expect(planned[0]?.action).toBe("get-1");
+		expect(planned[1]?.action).toBe("get-profile");
+		expect(planned[2]?.action).toBe("get-2");
+	});
+
 	test("falls back to path segment when operationId has no extra info", () => {
 		const ops: NormalizedOperation[] = [
 			{

--- a/src/cli/model/naming.test.ts
+++ b/src/cli/model/naming.test.ts
@@ -151,6 +151,69 @@ describe("planOperations collision handling", () => {
 		expect(planned[2]?.action).toBe("get-files");
 	});
 
+	test("disambiguated names never collide with each other", () => {
+		// Both operationIds reduce to the same disambiguator ("priorities"),
+		// which used to produce two `list-priorities` commands.
+		const ops: NormalizedOperation[] = [
+			{
+				key: "GET /priority",
+				method: "GET",
+				path: "/priority",
+				operationId: "getPriorities",
+				tags: ["Issue priorities"],
+				parameters: [],
+			},
+			{
+				key: "GET /priority/search",
+				method: "GET",
+				path: "/priority/search",
+				operationId: "searchPriorities",
+				tags: ["Issue priorities"],
+				parameters: [],
+			},
+		];
+
+		const planned = planOperations(ops);
+		expect(planned[0]?.action).toBe("list-priorities");
+		expect(planned[1]?.action).toBe("list-search");
+	});
+
+	test("disambiguated names never collide with an unrelated command", () => {
+		// `list-events` is already taken by a non-colliding operation, so the
+		// colliding one must fall through to another candidate.
+		const ops: NormalizedOperation[] = [
+			{
+				key: "GET /events",
+				method: "GET",
+				path: "/events",
+				operationId: "listProjectEvents",
+				tags: ["projects"],
+				parameters: [],
+			},
+			{
+				key: "GET /projects",
+				method: "GET",
+				path: "/projects",
+				operationId: "listProjects",
+				tags: ["projects"],
+				parameters: [],
+			},
+			{
+				key: "GET /teams/events",
+				method: "GET",
+				path: "/teams/events",
+				operationId: "listProjectEventsByTeam",
+				tags: ["projects"],
+				parameters: [],
+			},
+		];
+
+		const planned = planOperations(ops);
+		expect(planned[0]?.action).toBe("list-events");
+		expect(planned[1]?.action).toBe("list-1");
+		expect(planned[2]?.action).toBe("list-events-by-team");
+	});
+
 	test("no collision means no suffix", () => {
 		const ops: NormalizedOperation[] = [
 			{

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -178,8 +178,8 @@ function extractDisambiguator(
 
 /**
  * Meaningful action candidates for a colliding operation, most specific first:
- * the distinguishing part of the operationId, then the path segments that are
- * not already represented by the resource.
+ * the distinguishing part of the operationId, then a path segment that the
+ * resource does not already represent.
  */
 function disambiguationCandidates(op: PlannedOperation): string[] {
 	const candidates: string[] = [];
@@ -193,12 +193,16 @@ function disambiguationCandidates(op: PlannedOperation): string[] {
 		if (disambiguator) candidates.push(`${op.action}-${disambiguator}`);
 	}
 
+	const segments = getPathSegments(op.path);
+	// Look for the last non-parameter segment that isn't the resource
 	const singularResource = op.resource.replace(/s$/, "");
-	for (const segment of getPathSegments(op.path).reverse()) {
-		if (segment.startsWith("{")) continue;
-		const kebabSegment = kebabCase(segment);
-		if (kebabSegment !== op.resource && kebabSegment !== singularResource) {
-			candidates.push(`${op.action}-${kebabSegment}`);
+	for (let i = segments.length - 1; i >= 0; i--) {
+		const seg = segments[i];
+		if (!seg || seg.startsWith("{")) continue;
+		const kebabSeg = kebabCase(seg);
+		if (kebabSeg !== op.resource && kebabSeg !== singularResource) {
+			candidates.push(`${op.action}-${kebabSeg}`);
+			break;
 		}
 	}
 

--- a/src/cli/model/naming.ts
+++ b/src/cli/model/naming.ts
@@ -177,37 +177,52 @@ function extractDisambiguator(
 }
 
 /**
- * Derives a disambiguated action name for colliding operations.
- * Tries to create meaningful names like "get-events" instead of "get-get-deployment-events-1".
+ * Meaningful action candidates for a colliding operation, most specific first:
+ * the distinguishing part of the operationId, then the path segments that are
+ * not already represented by the resource.
  */
-function deriveDisambiguatedAction(op: PlannedOperation, idx: number): string {
+function disambiguationCandidates(op: PlannedOperation): string[] {
+	const candidates: string[] = [];
+
 	if (op.operationId) {
 		const disambiguator = extractDisambiguator(
 			op.operationId,
 			op.action,
 			op.resource,
 		);
-		if (disambiguator) {
-			// Use the disambiguator directly as action: "upload-files", "get-events"
-			return `${op.action}-${disambiguator}`;
-		}
+		if (disambiguator) candidates.push(`${op.action}-${disambiguator}`);
 	}
 
-	// Fallback: try to extract something from the path
-	const segments = getPathSegments(op.path);
-	// Look for the last non-parameter segment that isn't the resource
 	const singularResource = op.resource.replace(/s$/, "");
-	for (let i = segments.length - 1; i >= 0; i--) {
-		const seg = segments[i];
-		if (!seg || seg.startsWith("{")) continue;
-		const kebabSeg = kebabCase(seg);
-		if (kebabSeg !== op.resource && kebabSeg !== singularResource) {
-			return `${op.action}-${kebabSeg}`;
+	for (const segment of getPathSegments(op.path).reverse()) {
+		if (segment.startsWith("{")) continue;
+		const kebabSegment = kebabCase(segment);
+		if (kebabSegment !== op.resource && kebabSegment !== singularResource) {
+			candidates.push(`${op.action}-${kebabSegment}`);
 		}
 	}
 
-	// Last resort: append numeric suffix
-	return `${op.action}-${idx}`;
+	return candidates;
+}
+
+/**
+ * Picks an action for a colliding operation that no other command on the same
+ * resource has claimed. Meaningful names are preferred; a numeric suffix is the
+ * always-available fallback.
+ */
+function pickUnclaimedAction(
+	op: PlannedOperation,
+	claimed: ReadonlySet<string>,
+): string {
+	const isFree = (action: string) => !claimed.has(`${op.resource}:${action}`);
+
+	for (const candidate of disambiguationCandidates(op)) {
+		if (isFree(candidate)) return candidate;
+	}
+
+	let suffix = 1;
+	while (!isFree(`${op.action}-${suffix}`)) suffix += 1;
+	return `${op.action}-${suffix}`;
 }
 
 function canonicalizeAction(action: string): string {
@@ -295,27 +310,29 @@ export function planOperation(op: NormalizedOperation): PlannedOperation {
 export function planOperations(ops: NormalizedOperation[]): PlannedOperation[] {
 	const planned = ops.map(planOperation);
 
-	// Stable collision handling: if resource+action repeats, add a suffix.
 	const counts = new Map<string, number>();
 	for (const op of planned) {
 		const key = `${op.resource}:${op.action}`;
 		counts.set(key, (counts.get(key) ?? 0) + 1);
 	}
 
-	const seen = new Map<string, number>();
+	// Operations with an already-unique name keep it; colliding ones then pick a
+	// name that nothing else has claimed.
+	const claimed = new Set<string>();
+	for (const [key, count] of counts) {
+		if (count === 1) claimed.add(key);
+	}
+
 	return planned.map((op) => {
 		const key = `${op.resource}:${op.action}`;
-		const total = counts.get(key) ?? 0;
-		if (total <= 1) return op;
+		if (counts.get(key) === 1) return op;
 
-		const idx = (seen.get(key) ?? 0) + 1;
-		seen.set(key, idx);
-
-		const disambiguatedAction = deriveDisambiguatedAction(op, idx);
+		const action = pickUnclaimedAction(op, claimed);
+		claimed.add(`${op.resource}:${action}`);
 
 		return {
 			...op,
-			action: disambiguatedAction,
+			action,
 			aliasOf: `${op.resource} ${op.canonicalAction}`,
 		};
 	});


### PR DESCRIPTION
This change fixes vercel-labs/specli#7. `specli exec` crashes with the error `cannot add command 'list-priorities'` when an OpenAPI specification (spec) defines more than one collection `GET` operation under a single tag. The Atlassian Jira Cloud REST API v3 spec triggers this crash, which makes it unusable with `specli`.

After this change, you can run `specli exec` against specs that define multiple collection `GET` operations under one tag.

## What causes the crash

`planOperations` renames operations when their `resource:action` pair repeats, but it doesn't check whether the renamed actions are themselves unique. In the reproduction case from the issue, two `operationId` values reduce to the same disambiguator:

- `getPriorities` loses its `get-` prefix, becomes `priorities`, and produces `list-priorities`.
- `searchPriorities` loses its `search-` prefix, becomes `priorities`, and produces `list-priorities`.

Commander throws an error when it registers the second command. The code that resolves collisions creates a collision of its own.

## How the fix works

Disambiguation now generates a list of candidate names and selects the first name that no other command claims:

- `disambiguationCandidates` replaces `deriveDisambiguatedAction`. It returns the candidate names, which are the name derived from the `operationId` followed by a path segment, instead of selecting one name without checking it.
- `pickUnclaimedAction` checks each candidate against the set of claimed `resource:action` keys. When every candidate is taken, it appends a numeric suffix.
- `planOperations` adds the already-unique names to the claimed set before disambiguation begins, so a renamed command can't take a name that another command already uses. It adds each new name to the set as it assigns it.

Uniqueness is now a property of the algorithm rather than an assumption. The numeric suffix replaces the per-collision-group counter.

The change affects one file and about 40 lines. The path-segment loop changes only from `return` to `push` and `break`, because the function now collects candidates instead of returning them one at a time.

## Validation against the Jira Cloud v3 spec

The live spec from `developer.atlassian.com` contains 617 operations across 2.4 MB. Before this change, `specli exec` crashes in `addGeneratedCommands`. After this change, the spec loads and every command registers.

| Check | Result |
| --- | --- |
| Operations in the spec | 617 |
| Commands in the model | 617, so the fix drops no operations |
| Distinct operation keys | 617, so no command shadows another |
| Duplicate `resource action` names | 0, down from four names across eight operations |

Of the 414 operations that require disambiguation, 412 receive a name derived from the `operationId` or the path, and two fall back to a numeric suffix.

### Naming changes on this spec

Four names collided before this change. The fix renames those four operations and no others. In each pair, the first operation keeps its name and the second operation receives a new name.

| Operation | `operationId` | Name before | Name after |
| --- | --- | --- | --- |
| `GET /priority` | `getPriorities` | `issue-priorities list-priorities` | Unchanged |
| `GET /priority/search` | `searchPriorities` | `issue-priorities list-priorities`, a duplicate | `issue-priorities list-search` |
| `GET /resolution` | `getResolutions` | `issue-resolutions list-resolutions` | Unchanged |
| `GET /resolution/search` | `searchResolutions` | `issue-resolutions list-resolutions`, a duplicate | `issue-resolutions list-search` |
| `GET /issue/{issueIdOrKey}/worklog` | `getIssueWorklog` | `issue-worklogs get-worklog` | Unchanged |
| `GET /issue/{issueIdOrKey}/worklog/{id}` | `getWorklog` | `issue-worklogs get-worklog`, a duplicate | `issue-worklogs get-1` |
| `GET /project/{projectIdOrKey}/role` | `getProjectRoles` | `project-roles get-role` | Unchanged |
| `GET /project/{projectIdOrKey}/role/{id}` | `getProjectRole` | `project-roles get-role`, a duplicate | `project-roles get-1` |

The two `/search` operations receive descriptive names. The other two operations receive `get-1`, because their paths follow the `/{parent}/{child}/{id}` pattern, in which every segment that isn't a parameter already matches the resource name, and their `operationId` values contain no additional information. These two names are unique and correct, but they don't describe the operation. For a possible improvement, see [Follow-up work](#follow-up-work).

### Specs without collisions

The same comparison against other published specs produces no naming changes:

| Spec | Operations | Names changed |
| --- | --- | --- |
| Box | 296 | 0 |
| Swagger Petstore v3 | 19 | 0 |

The Jira comparison also shows no renumbering. Wherever the previous counter produced a valid name, the numeric suffix produces the same name.

Two other specs remain unevaluated. The DigitalOcean spec spans multiple files with relative `$ref` values, so it doesn't resolve on its own. The Stripe spec, at 8 MB, didn't finish dereferencing within nine minutes in the test environment.

## Behavior

The eight rows in the preceding table describe every naming change. The existing test expectations, which are `get-1`, `create-v13`, `get-events`, and `get-profile`, remain unchanged.

The reproduction case from the issue now produces two working commands:

```
$ specli exec ./repro.json issue-priorities list-priorities --curl
curl -sS -X GET 'https://example.com/priority'

$ specli exec ./repro.json issue-priorities list-search --curl
curl -sS -X GET 'https://example.com/priority/search'
```

## Test results

`naming.test.ts` gains two regression tests: one for two operations whose `operationId` values reduce to the same disambiguator, and one for a renamed command that collides with an unrelated command.

- `bun test`: 135 tests pass, and none fail.
- `bun run lint`: no errors.
- `bun run typecheck`: no errors.

## Follow-up work

The following items fall outside the scope of this change:

1. **Version segments produce unhelpful names.** The path fallback selects the last segment that doesn't match the resource, so a path such as `/rest/api/3/dashboard/{id}` produces a name such as `dashboards get-3`. This behavior predates this change. Skipping segments that contain only a version number would improve about 15 names in the Jira spec.
1. **The `typecheck` script writes build output.** The script runs `tsgo` without `--noEmit`, so it creates `dist/`. As a result, `biome ci` checks 224 files instead of 82, and `bun test` runs each test twice: once from `src` and once from the compiled copy.
1. **Seven tests depend on network access.** These tests call `petstore3.swagger.io` and `httpbin.org`, so they time out in environments that restrict outbound requests.